### PR TITLE
Change the dwFlags of STARTUPINFO

### DIFF
--- a/ProcessExtensions/ProcessExtensions.cs
+++ b/ProcessExtensions/ProcessExtensions.cs
@@ -14,7 +14,8 @@ namespace murrayju.ProcessExtensions
 
         private const uint INVALID_SESSION_ID = 0xFFFFFFFF;
         private static readonly IntPtr WTS_CURRENT_SERVER_HANDLE = IntPtr.Zero;
-
+        private const int STARTF_USESHOWWINDOW = 0x00000001;
+        
         #endregion
 
         #region DllImports
@@ -225,6 +226,7 @@ namespace murrayju.ProcessExtensions
                 }
 
                 uint dwCreationFlags = CREATE_UNICODE_ENVIRONMENT | (uint)(visible ? CREATE_NEW_CONSOLE : CREATE_NO_WINDOW);
+                startInfo.dwFlags = STARTF_USESHOWWINDOW;
                 startInfo.wShowWindow = (short)(visible ? SW.SW_SHOW : SW.SW_HIDE);
                 startInfo.lpDesktop = "winsta0\\default";
 


### PR DESCRIPTION
Nothing happened after I adjusted the `wShowWindow` property to `SW_MINIMIZE`, and I found something description of `wShowWindow` property in MSDN:

If `dwFlags` specifies `STARTF_USESHOWWINDOW`, this member can be any of the values that can be specified in the `nCmdShow` parameter for the `ShowWindow` function, except for `SW_SHOWDEFAULT`. Otherwise, this member is ignored.

https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfoa