### PR TITLE
Integrate CsWin32 for Safer and More Maintainable P/Invoke Interop

### DIFF
--- a/ProcessExtensions/NativeMethods.txt
+++ b/ProcessExtensions/NativeMethods.txt
@@ -1,0 +1,9 @@
+﻿WTSEnumerateSessions
+WTSFreeMemory
+WTSGetActiveConsoleSessionId
+WTSQueryUserToken
+DuplicateTokenEx
+CreateEnvironmentBlock
+DestroyEnvironmentBlock
+CreateProcessAsUser
+SHOW_WINDOW_CMD

--- a/ProcessExtensions/ProcessExtensions.cs
+++ b/ProcessExtensions/ProcessExtensions.cs
@@ -9,139 +9,140 @@ using Windows.Win32.System.Threading;
 using Windows.Win32.UI.WindowsAndMessaging;
 using static Windows.Win32.PInvoke;
 
-namespace murrayju.ProcessExtensions;
-
-/// <summary>
-/// Custom exception for handling process creation failures.
-/// </summary>
-public class ProcessCreationException : Exception
+namespace murrayju.ProcessExtensions
 {
-    public ProcessCreationException(string msg) : base(msg) { }
-}
-
-/// <summary>
-/// Provides methods for creating processes under the active user session.
-/// </summary>
-public static class ProcessExtensions
-{
-    private const uint INVALID_SESSION_ID = 0xFFFFFFFF;
-
     /// <summary>
-    /// Retrieves the user token from the currently active session.
+    /// Custom exception for handling process creation failures.
     /// </summary>
-    /// <param name="phUserToken">A handle to the user token for the active session.</param>
-    /// <returns>True if the token retrieval is successful; otherwise, false.</returns>
-    private static unsafe bool GetSessionUserToken(ref SafeFileHandle phUserToken)
+    public class ProcessCreationException : Exception
     {
-        var bResult = false;
-        HANDLE hImpersonationToken = default;
-        var activeSessionId = INVALID_SESSION_ID;
-
-        if (WTSEnumerateSessions(HANDLE.Null, 0, 1, out var pSessionInfo, out var sessionCount) != 0)
-        {
-            var sessionInfo = pSessionInfo;
-
-            for (var i = 0; i < sessionCount; i++)
-            {
-                if (sessionInfo[i].State == WTS_CONNECTSTATE_CLASS.WTSActive)
-                {
-                    activeSessionId = sessionInfo[i].SessionId;
-                    break;
-                }
-            }
-
-            WTSFreeMemory(pSessionInfo);
-        }
-
-        if (activeSessionId == INVALID_SESSION_ID)
-        {
-            activeSessionId = WTSGetActiveConsoleSessionId();
-
-            if (activeSessionId == INVALID_SESSION_ID)
-            {
-                return false;
-            }
-        }
-
-        if (WTSQueryUserToken(activeSessionId, ref hImpersonationToken) != 0)
-        {
-            var hImpersonationTokenSafe = new SafeFileHandle(hImpersonationToken, true);
-
-            bResult = DuplicateTokenEx(hImpersonationTokenSafe, 0, null, SECURITY_IMPERSONATION_LEVEL.SecurityImpersonation, TOKEN_TYPE.TokenPrimary, out phUserToken);
-
-            CloseHandle(hImpersonationToken);
-        }
-
-        return bResult;
+        public ProcessCreationException(string msg) : base(msg) { }
     }
 
     /// <summary>
-    /// Starts a process as the current active user.
+    /// Provides methods for creating processes under the active user session.
     /// </summary>
-    /// <param name="appPath">The path to the application to start.</param>
-    /// <param name="cmdLine">The command line arguments for the process.</param>
-    /// <param name="workDir">The working directory for the process.</param>
-    /// <param name="visible">Whether the process window should be visible.</param>
-    /// <returns>True if the process starts successfully; otherwise, false.</returns>
-    /// <exception cref="ProcessCreationException">Thrown when the process could not be started.</exception>
-    public unsafe static bool StartProcessAsCurrentUser(string appPath, string? cmdLine = null, string? workDir = null, bool visible = true)
+    public static class ProcessExtensions
     {
-        SafeFileHandle? hUserToken = null;
-        var startInfo = new STARTUPINFOW();
-        var procInfo = new PROCESS_INFORMATION();
-        void* pEnv = null;
-        int iResultOfCreateProcessAsUser;
+        private const uint INVALID_SESSION_ID = 0xFFFFFFFF;
 
-        startInfo.cb = (uint)Marshal.SizeOf(typeof(STARTUPINFOW));
-
-        try
+        /// <summary>
+        /// Retrieves the user token from the currently active session.
+        /// </summary>
+        /// <param name="phUserToken">A handle to the user token for the active session.</param>
+        /// <returns>True if the token retrieval is successful; otherwise, false.</returns>
+        private static unsafe bool GetSessionUserToken(ref SafeFileHandle phUserToken)
         {
-            if (!GetSessionUserToken(ref hUserToken))
+            var bResult = false;
+            HANDLE hImpersonationToken = default;
+            var activeSessionId = INVALID_SESSION_ID;
+
+            if (WTSEnumerateSessions(HANDLE.Null, 0, 1, out var pSessionInfo, out var sessionCount) != 0)
             {
-                throw new ProcessCreationException("StartProcessAsCurrentUser: GetSessionUserToken failed.");
+                var sessionInfo = pSessionInfo;
+
+                for (var i = 0; i < sessionCount; i++)
+                {
+                    if (sessionInfo[i].State == WTS_CONNECTSTATE_CLASS.WTSActive)
+                    {
+                        activeSessionId = sessionInfo[i].SessionId;
+                        break;
+                    }
+                }
+
+                WTSFreeMemory(pSessionInfo);
             }
 
-            var dwCreationFlags = PROCESS_CREATION_FLAGS.CREATE_UNICODE_ENVIRONMENT | (visible ? PROCESS_CREATION_FLAGS.CREATE_NEW_CONSOLE : PROCESS_CREATION_FLAGS.CREATE_NO_WINDOW);
-            startInfo.dwFlags = STARTUPINFOW_FLAGS.STARTF_USESHOWWINDOW;
-            startInfo.wShowWindow = (ushort)(visible ? SHOW_WINDOW_CMD.SW_SHOW : SHOW_WINDOW_CMD.SW_HIDE);
-
-            fixed (char* pDesktopName = $@"winsta0\Default")
+            if (activeSessionId == INVALID_SESSION_ID)
             {
-                startInfo.lpDesktop = pDesktopName;
+                activeSessionId = WTSGetActiveConsoleSessionId();
+
+                if (activeSessionId == INVALID_SESSION_ID)
+                {
+                    return false;
+                }
             }
 
-            if (!CreateEnvironmentBlock(out pEnv, hUserToken, false))
+            if (WTSQueryUserToken(activeSessionId, ref hImpersonationToken) != 0)
             {
-                throw new ProcessCreationException("StartProcessAsCurrentUser: CreateEnvironmentBlock failed.");
+                var hImpersonationTokenSafe = new SafeFileHandle(hImpersonationToken, true);
+
+                bResult = DuplicateTokenEx(hImpersonationTokenSafe, 0, null, SECURITY_IMPERSONATION_LEVEL.SecurityImpersonation, TOKEN_TYPE.TokenPrimary, out phUserToken);
+
+                CloseHandle(hImpersonationToken);
             }
 
-            if (workDir != null)
-            {
-                Directory.SetCurrentDirectory(workDir);
-            }
+            return bResult;
+        }
 
-            cmdLine += char.MinValue;
-            var commandSpan = new Span<char>(cmdLine.ToCharArray());
+        /// <summary>
+        /// Starts a process as the current active user.
+        /// </summary>
+        /// <param name="appPath">The path to the application to start.</param>
+        /// <param name="cmdLine">The command line arguments for the process.</param>
+        /// <param name="workDir">The working directory for the process.</param>
+        /// <param name="visible">Whether the process window should be visible.</param>
+        /// <returns>True if the process starts successfully; otherwise, false.</returns>
+        /// <exception cref="ProcessCreationException">Thrown when the process could not be started.</exception>
+        public unsafe static bool StartProcessAsCurrentUser(string appPath, string cmdLine = null, string workDir = null, bool visible = true)
+        {
+            SafeFileHandle hUserToken = null;
+            var startInfo = new STARTUPINFOW();
+            var procInfo = new PROCESS_INFORMATION();
+            void* pEnv = null;
+            int iResultOfCreateProcessAsUser;
 
-            if (!CreateProcessAsUser(hUserToken, appPath, ref commandSpan, null, null, false, dwCreationFlags, pEnv, workDir, startInfo, out procInfo))
+            startInfo.cb = (uint)Marshal.SizeOf(typeof(STARTUPINFOW));
+
+            try
             {
+                if (!GetSessionUserToken(ref hUserToken))
+                {
+                    throw new ProcessCreationException("StartProcessAsCurrentUser: GetSessionUserToken failed.");
+                }
+
+                var dwCreationFlags = PROCESS_CREATION_FLAGS.CREATE_UNICODE_ENVIRONMENT | (visible ? PROCESS_CREATION_FLAGS.CREATE_NEW_CONSOLE : PROCESS_CREATION_FLAGS.CREATE_NO_WINDOW);
+                startInfo.dwFlags = STARTUPINFOW_FLAGS.STARTF_USESHOWWINDOW;
+                startInfo.wShowWindow = (ushort)(visible ? SHOW_WINDOW_CMD.SW_SHOW : SHOW_WINDOW_CMD.SW_HIDE);
+
+                fixed (char* pDesktopName = $@"winsta0\Default")
+                {
+                    startInfo.lpDesktop = pDesktopName;
+                }
+
+                if (!CreateEnvironmentBlock(out pEnv, hUserToken, false))
+                {
+                    throw new ProcessCreationException("StartProcessAsCurrentUser: CreateEnvironmentBlock failed.");
+                }
+
+                if (workDir != null)
+                {
+                    Directory.SetCurrentDirectory(workDir);
+                }
+
+                cmdLine += char.MinValue;
+                var commandSpan = new Span<char>(cmdLine.ToCharArray());
+
+                if (!CreateProcessAsUser(hUserToken, appPath, ref commandSpan, null, null, false, dwCreationFlags, pEnv, workDir, startInfo, out procInfo))
+                {
+                    iResultOfCreateProcessAsUser = Marshal.GetLastWin32Error();
+                    throw new ProcessCreationException("StartProcessAsCurrentUser: CreateProcessAsUser failed. Error Code -" + iResultOfCreateProcessAsUser);
+                }
+
                 iResultOfCreateProcessAsUser = Marshal.GetLastWin32Error();
-                throw new ProcessCreationException("StartProcessAsCurrentUser: CreateProcessAsUser failed. Error Code -" + iResultOfCreateProcessAsUser);
             }
-
-            iResultOfCreateProcessAsUser = Marshal.GetLastWin32Error();
-        }
-        finally
-        {
-            if (pEnv != null)
+            finally
             {
-                DestroyEnvironmentBlock(pEnv);
+                if (pEnv != null)
+                {
+                    DestroyEnvironmentBlock(pEnv);
+                }
+
+                CloseHandle(procInfo.hThread);
+                CloseHandle(procInfo.hProcess);
             }
 
-            CloseHandle(procInfo.hThread);
-            CloseHandle(procInfo.hProcess);
+            return true;
         }
-
-        return true;
     }
 }

--- a/ProcessExtensions/ProcessExtensions.cs
+++ b/ProcessExtensions/ProcessExtensions.cs
@@ -1,287 +1,147 @@
-﻿using System;
+﻿using Microsoft.Win32.SafeHandles;
+using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Windows.Win32.Foundation;
+using Windows.Win32.Security;
+using Windows.Win32.System.RemoteDesktop;
+using Windows.Win32.System.Threading;
+using Windows.Win32.UI.WindowsAndMessaging;
+using static Windows.Win32.PInvoke;
 
-namespace murrayju.ProcessExtensions
+namespace murrayju.ProcessExtensions;
+
+/// <summary>
+/// Custom exception for handling process creation failures.
+/// </summary>
+public class ProcessCreationException : Exception
 {
-    public class ProcessCreationException : Exception
+    public ProcessCreationException(string msg) : base(msg) { }
+}
+
+/// <summary>
+/// Provides methods for creating processes under the active user session.
+/// </summary>
+public static class ProcessExtensions
+{
+    private const uint INVALID_SESSION_ID = 0xFFFFFFFF;
+
+    /// <summary>
+    /// Retrieves the user token from the currently active session.
+    /// </summary>
+    /// <param name="phUserToken">A handle to the user token for the active session.</param>
+    /// <returns>True if the token retrieval is successful; otherwise, false.</returns>
+    private static unsafe bool GetSessionUserToken(ref SafeFileHandle phUserToken)
     {
-        public ProcessCreationException(string msg) : base(msg) { }
-    }
+        var bResult = false;
+        HANDLE hImpersonationToken = default;
+        var activeSessionId = INVALID_SESSION_ID;
 
-    public static class ProcessExtensions
-    {
-        #region Win32 Constants
-
-        private const int CREATE_UNICODE_ENVIRONMENT = 0x00000400;
-        private const int CREATE_NO_WINDOW = 0x08000000;
-
-        private const int CREATE_NEW_CONSOLE = 0x00000010;
-
-        private const uint INVALID_SESSION_ID = 0xFFFFFFFF;
-        private static readonly IntPtr WTS_CURRENT_SERVER_HANDLE = IntPtr.Zero;
-        private const int STARTF_USESHOWWINDOW = 0x00000001;
-        
-        #endregion
-
-        #region DllImports
-
-        [DllImport("advapi32.dll", EntryPoint = "CreateProcessAsUser", SetLastError = true, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
-        private static extern bool CreateProcessAsUser(
-            IntPtr hToken,
-            String lpApplicationName,
-            String lpCommandLine,
-            IntPtr lpProcessAttributes,
-            IntPtr lpThreadAttributes,
-            bool bInheritHandle,
-            uint dwCreationFlags,
-            IntPtr lpEnvironment,
-            String lpCurrentDirectory,
-            ref STARTUPINFO lpStartupInfo,
-            out PROCESS_INFORMATION lpProcessInformation);
-
-        [DllImport("advapi32.dll", EntryPoint = "DuplicateTokenEx")]
-        private static extern bool DuplicateTokenEx(
-            IntPtr ExistingTokenHandle,
-            uint dwDesiredAccess,
-            IntPtr lpThreadAttributes,
-            int TokenType,
-            int ImpersonationLevel,
-            ref IntPtr DuplicateTokenHandle);
-
-        [DllImport("userenv.dll", SetLastError = true)]
-        private static extern bool CreateEnvironmentBlock(ref IntPtr lpEnvironment, IntPtr hToken, bool bInherit);
-
-        [DllImport("userenv.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool DestroyEnvironmentBlock(IntPtr lpEnvironment);
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern bool CloseHandle(IntPtr hSnapshot);
-
-        [DllImport("kernel32.dll")]
-        private static extern uint WTSGetActiveConsoleSessionId();
-
-        [DllImport("Wtsapi32.dll")]
-        private static extern uint WTSQueryUserToken(uint SessionId, ref IntPtr phToken);
-
-        [DllImport("wtsapi32.dll", SetLastError = true)]
-        private static extern int WTSEnumerateSessions(
-            IntPtr hServer,
-            int Reserved,
-            int Version,
-            ref IntPtr ppSessionInfo,
-            ref int pCount);
-
-        [DllImport("Wtsapi32.dll")]
-        private static extern void WTSFreeMemory(IntPtr ppSessionInfo);
-
-        #endregion
-
-        #region Win32 Structs
-
-        private enum SW
+        if (WTSEnumerateSessions(HANDLE.Null, 0, 1, out var pSessionInfo, out var sessionCount) != 0)
         {
-            SW_HIDE = 0,
-            SW_SHOWNORMAL = 1,
-            SW_NORMAL = 1,
-            SW_SHOWMINIMIZED = 2,
-            SW_SHOWMAXIMIZED = 3,
-            SW_MAXIMIZE = 3,
-            SW_SHOWNOACTIVATE = 4,
-            SW_SHOW = 5,
-            SW_MINIMIZE = 6,
-            SW_SHOWMINNOACTIVE = 7,
-            SW_SHOWNA = 8,
-            SW_RESTORE = 9,
-            SW_SHOWDEFAULT = 10,
-            SW_MAX = 10
-        }
+            var sessionInfo = pSessionInfo;
 
-        private enum WTS_CONNECTSTATE_CLASS
-        {
-            WTSActive,
-            WTSConnected,
-            WTSConnectQuery,
-            WTSShadow,
-            WTSDisconnected,
-            WTSIdle,
-            WTSListen,
-            WTSReset,
-            WTSDown,
-            WTSInit
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct PROCESS_INFORMATION
-        {
-            public IntPtr hProcess;
-            public IntPtr hThread;
-            public uint dwProcessId;
-            public uint dwThreadId;
-        }
-
-        private enum SECURITY_IMPERSONATION_LEVEL
-        {
-            SecurityAnonymous = 0,
-            SecurityIdentification = 1,
-            SecurityImpersonation = 2,
-            SecurityDelegation = 3,
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct STARTUPINFO
-        {
-            public int cb;
-            public String lpReserved;
-            public String lpDesktop;
-            public String lpTitle;
-            public uint dwX;
-            public uint dwY;
-            public uint dwXSize;
-            public uint dwYSize;
-            public uint dwXCountChars;
-            public uint dwYCountChars;
-            public uint dwFillAttribute;
-            public uint dwFlags;
-            public short wShowWindow;
-            public short cbReserved2;
-            public IntPtr lpReserved2;
-            public IntPtr hStdInput;
-            public IntPtr hStdOutput;
-            public IntPtr hStdError;
-        }
-
-        private enum TOKEN_TYPE
-        {
-            TokenPrimary = 1,
-            TokenImpersonation = 2
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct WTS_SESSION_INFO
-        {
-            public readonly UInt32 SessionID;
-
-            [MarshalAs(UnmanagedType.LPStr)]
-            public readonly String pWinStationName;
-
-            public readonly WTS_CONNECTSTATE_CLASS State;
-        }
-
-        #endregion
-
-        // Gets the user token from the currently active session
-        private static bool GetSessionUserToken(ref IntPtr phUserToken)
-        {
-            var bResult = false;
-            var hImpersonationToken = IntPtr.Zero;
-            var activeSessionId = INVALID_SESSION_ID;
-            var pSessionInfo = IntPtr.Zero;
-            var sessionCount = 0;
-
-            // Get a handle to the user access token for the current active session.
-            if (WTSEnumerateSessions(WTS_CURRENT_SERVER_HANDLE, 0, 1, ref pSessionInfo, ref sessionCount) != 0)
+            for (var i = 0; i < sessionCount; i++)
             {
-                var arrayElementSize = Marshal.SizeOf(typeof(WTS_SESSION_INFO));
-                var current = pSessionInfo;
-
-                for (var i = 0; i < sessionCount; i++)
+                if (sessionInfo[i].State == WTS_CONNECTSTATE_CLASS.WTSActive)
                 {
-                    var si = (WTS_SESSION_INFO)Marshal.PtrToStructure((IntPtr)current, typeof(WTS_SESSION_INFO));
-                    current += arrayElementSize;
-
-                    if (si.State == WTS_CONNECTSTATE_CLASS.WTSActive)
-                    {
-                        activeSessionId = si.SessionID;
-                    }
+                    activeSessionId = sessionInfo[i].SessionId;
+                    break;
                 }
-
-                WTSFreeMemory(pSessionInfo);
             }
 
-            // If enumerating did not work, fall back to the old method
+            WTSFreeMemory(pSessionInfo);
+        }
+
+        if (activeSessionId == INVALID_SESSION_ID)
+        {
+            activeSessionId = WTSGetActiveConsoleSessionId();
+
             if (activeSessionId == INVALID_SESSION_ID)
             {
-                activeSessionId = WTSGetActiveConsoleSessionId();
+                return false;
             }
-
-            if (WTSQueryUserToken(activeSessionId, ref hImpersonationToken) != 0)
-            {
-                // Convert the impersonation token to a primary token
-                bResult = DuplicateTokenEx(hImpersonationToken, 0, IntPtr.Zero,
-                    (int)SECURITY_IMPERSONATION_LEVEL.SecurityImpersonation, (int)TOKEN_TYPE.TokenPrimary,
-                    ref phUserToken);
-
-                CloseHandle(hImpersonationToken);
-            }
-
-            return bResult;
         }
 
-        public static bool StartProcessAsCurrentUser(string appPath, string cmdLine = null, string workDir = null, bool visible = true)
+        if (WTSQueryUserToken(activeSessionId, ref hImpersonationToken) != 0)
         {
-            var hUserToken = IntPtr.Zero;
-            var startInfo = new STARTUPINFO();
-            var procInfo = new PROCESS_INFORMATION();
-            var pEnv = IntPtr.Zero;
-            int iResultOfCreateProcessAsUser;
+            var hImpersonationTokenSafe = new SafeFileHandle(hImpersonationToken, true);
 
-            startInfo.cb = Marshal.SizeOf(typeof(STARTUPINFO));
+            bResult = DuplicateTokenEx(hImpersonationTokenSafe, 0, null, SECURITY_IMPERSONATION_LEVEL.SecurityImpersonation, TOKEN_TYPE.TokenPrimary, out phUserToken);
 
-            try
-            {
-                if (!GetSessionUserToken(ref hUserToken))
-                {
-                    throw new ProcessCreationException("StartProcessAsCurrentUser: GetSessionUserToken failed.");
-                }
-
-                uint dwCreationFlags = CREATE_UNICODE_ENVIRONMENT | (uint)(visible ? CREATE_NEW_CONSOLE : CREATE_NO_WINDOW);
-                startInfo.dwFlags = STARTF_USESHOWWINDOW;
-                startInfo.wShowWindow = (short)(visible ? SW.SW_SHOW : SW.SW_HIDE);
-                startInfo.lpDesktop = "winsta0\\default";
-
-                if (!CreateEnvironmentBlock(ref pEnv, hUserToken, false))
-                {
-                    throw new ProcessCreationException("StartProcessAsCurrentUser: CreateEnvironmentBlock failed.");
-                }
-
-                if (workDir != null)
-                {
-                    Directory.SetCurrentDirectory(workDir);
-                }
-
-                if (!CreateProcessAsUser(hUserToken,
-                    appPath, // Application Name
-                    cmdLine, // Command Line
-                    IntPtr.Zero,
-                    IntPtr.Zero,
-                    false,
-                    dwCreationFlags,
-                    pEnv,
-                    workDir, // Working directory
-                    ref startInfo,
-                    out procInfo))
-                {
-                    iResultOfCreateProcessAsUser = Marshal.GetLastWin32Error();
-                    throw new ProcessCreationException("StartProcessAsCurrentUser: CreateProcessAsUser failed.  Error Code -" + iResultOfCreateProcessAsUser);
-                }
-
-                iResultOfCreateProcessAsUser = Marshal.GetLastWin32Error();
-            }
-            finally
-            {
-                CloseHandle(hUserToken);
-                if (pEnv != IntPtr.Zero)
-                {
-                    DestroyEnvironmentBlock(pEnv);
-                }
-                CloseHandle(procInfo.hThread);
-                CloseHandle(procInfo.hProcess);
-            }
-
-            return true;
+            CloseHandle(hImpersonationToken);
         }
 
+        return bResult;
+    }
+
+    /// <summary>
+    /// Starts a process as the current active user.
+    /// </summary>
+    /// <param name="appPath">The path to the application to start.</param>
+    /// <param name="cmdLine">The command line arguments for the process.</param>
+    /// <param name="workDir">The working directory for the process.</param>
+    /// <param name="visible">Whether the process window should be visible.</param>
+    /// <returns>True if the process starts successfully; otherwise, false.</returns>
+    /// <exception cref="ProcessCreationException">Thrown when the process could not be started.</exception>
+    public unsafe static bool StartProcessAsCurrentUser(string appPath, string? cmdLine = null, string? workDir = null, bool visible = true)
+    {
+        SafeFileHandle? hUserToken = null;
+        var startInfo = new STARTUPINFOW();
+        var procInfo = new PROCESS_INFORMATION();
+        void* pEnv = null;
+        int iResultOfCreateProcessAsUser;
+
+        startInfo.cb = (uint)Marshal.SizeOf(typeof(STARTUPINFOW));
+
+        try
+        {
+            if (!GetSessionUserToken(ref hUserToken))
+            {
+                throw new ProcessCreationException("StartProcessAsCurrentUser: GetSessionUserToken failed.");
+            }
+
+            var dwCreationFlags = PROCESS_CREATION_FLAGS.CREATE_UNICODE_ENVIRONMENT | (visible ? PROCESS_CREATION_FLAGS.CREATE_NEW_CONSOLE : PROCESS_CREATION_FLAGS.CREATE_NO_WINDOW);
+            startInfo.dwFlags = STARTUPINFOW_FLAGS.STARTF_USESHOWWINDOW;
+            startInfo.wShowWindow = (ushort)(visible ? SHOW_WINDOW_CMD.SW_SHOW : SHOW_WINDOW_CMD.SW_HIDE);
+
+            fixed (char* pDesktopName = $@"winsta0\Default")
+            {
+                startInfo.lpDesktop = pDesktopName;
+            }
+
+            if (!CreateEnvironmentBlock(out pEnv, hUserToken, false))
+            {
+                throw new ProcessCreationException("StartProcessAsCurrentUser: CreateEnvironmentBlock failed.");
+            }
+
+            if (workDir != null)
+            {
+                Directory.SetCurrentDirectory(workDir);
+            }
+
+            cmdLine += char.MinValue;
+            var commandSpan = new Span<char>(cmdLine.ToCharArray());
+
+            if (!CreateProcessAsUser(hUserToken, appPath, ref commandSpan, null, null, false, dwCreationFlags, pEnv, workDir, startInfo, out procInfo))
+            {
+                iResultOfCreateProcessAsUser = Marshal.GetLastWin32Error();
+                throw new ProcessCreationException("StartProcessAsCurrentUser: CreateProcessAsUser failed. Error Code -" + iResultOfCreateProcessAsUser);
+            }
+
+            iResultOfCreateProcessAsUser = Marshal.GetLastWin32Error();
+        }
+        finally
+        {
+            if (pEnv != null)
+            {
+                DestroyEnvironmentBlock(pEnv);
+            }
+
+            CloseHandle(procInfo.hThread);
+            CloseHandle(procInfo.hProcess);
+        }
+
+        return true;
     }
 }

--- a/ProcessExtensions/ProcessExtensions.csproj
+++ b/ProcessExtensions/ProcessExtensions.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ProcessExtensions/ProcessExtensions.csproj
+++ b/ProcessExtensions/ProcessExtensions.csproj
@@ -2,6 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.51-beta">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Windows.SDK.Win32Metadata" Version="56.0.13-preview" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Changes
In this Pull Request, I have refactored the existing manual P/Invoke definitions to use the CsWin32 generated APIs. This transition introduces a modern approach that simplifies code maintenance and reduces the risk of errors associated with interop calls.

## Why CsWin32?
CsWin32 is a tool provided by Microsoft that allows for safe and efficient Win32 API calls from C#. It automatically generates precise and type-safe P/Invoke signatures, enabling developers to avoid the manual writing of interop code and the potential mistakes that come with it.

## Benefits
- **Type Safety**: CsWin32 provides strict type checking, preventing common errors that can occur with manual P/Invoke signatures.
- **Maintenance**: Automated generation of interop signatures eases the burden of keeping up with API changes in Windows SDK updates.
- **Performance**: CsWin32 aims to offer optimized calls to native APIs, with minimal overhead.

## Impact of Changes
- **Codebase**: The changes lead to a cleaner codebase, improving readability and future-proofing the code.
- **Compatibility**: These updates maintain backward compatibility with the existing functionality of the application.

I believe these changes align well with the project's ongoing efforts to adopt modern .NET practices and will contribute to its overall robustness. I look forward to your feedback and any further improvements you may suggest.

Thank you for considering this contribution.