### PR TITLE
Starting apps with administrative privileges in interactive sessions.

### DIFF
--- a/AppWithPrivileges/App.xaml
+++ b/AppWithPrivileges/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="AppWithPrivileges.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:AppWithPrivileges"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/AppWithPrivileges/App.xaml.cs
+++ b/AppWithPrivileges/App.xaml.cs
@@ -1,0 +1,14 @@
+﻿using System.Configuration;
+using System.Data;
+using System.Windows;
+
+namespace AppWithPrivileges
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+    }
+
+}

--- a/AppWithPrivileges/AppWithPrivileges.csproj
+++ b/AppWithPrivileges/AppWithPrivileges.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+
+</Project>

--- a/AppWithPrivileges/AssemblyInfo.cs
+++ b/AppWithPrivileges/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/AppWithPrivileges/MainWindow.xaml
+++ b/AppWithPrivileges/MainWindow.xaml
@@ -1,0 +1,15 @@
+﻿<Window x:Class="AppWithPrivileges.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:AppWithPrivileges"
+        mc:Ignorable="d"
+        Title="App" Height="450" Width="800">
+    <Grid>
+        <Label FontSize="20"
+               FontFamily="Verdana" VerticalAlignment="Center" HorizontalAlignment="Center">
+            This is an App with privliges
+        </Label>
+    </Grid>
+</Window>

--- a/AppWithPrivileges/MainWindow.xaml.cs
+++ b/AppWithPrivileges/MainWindow.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace AppWithPrivileges
+{
+    /// <summary>
+    /// Interaction logic for MainWindow.xaml
+    /// </summary>
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/AppWithPrivileges/app.manifest
+++ b/AppWithPrivileges/app.manifest
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. 
+       
+       Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+  <!--
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+  -->
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>

--- a/DemoModernService/DemoModernService.cs
+++ b/DemoModernService/DemoModernService.cs
@@ -15,12 +15,6 @@ internal class DemoModernService : BackgroundService
         string targetProjectName = Path.GetFileNameWithoutExtension(appPath);
         string workDir = Path.Combine(solutionDirectory, targetProjectName, "bin", "Debug", "net6.0-windows");
 
-        /* NOTE YOU MUST COMMENT ONE OF THE BELOW LINES BASED ON YOUR CHOICE OF RUNNING THE SERVICE */
-
-        // DEBUG MODE
-        ProcessExtensions.LaunchProcess(appPath: appPath, workDir: workDir, asAdmin: false);
-
-        // SERVICE MODE
-        ProcessExtensions.LaunchProcess(appPath: appPath, workDir: workDir, asAdmin: true);
+        ProcessExtensions.LaunchProcess(appPath: appPath, workDir: workDir);
     }
 }

--- a/DemoModernService/DemoModernService.cs
+++ b/DemoModernService/DemoModernService.cs
@@ -9,16 +9,18 @@ internal class DemoModernService : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        string path = AppDomain.CurrentDomain.BaseDirectory;
-        int levelsUp = 5;
-        for (int i = 0; i < levelsUp; i++)
-        {
-            path = Directory.GetParent(path)?.FullName ?? path;
-        }
-        Debug.WriteLine("OUTPUT PATH: " + path);
         string appPath = "AppWithPrivileges.exe";
-        string? workDir = Path.Combine(path, "AppWithPrivileges", "bin", "Debug", "net6.0-windows");
-        ProcessExtensions.StartProcessAsCurrentUser(appPath: appPath, workDir: workDir);
-        //ProcessExtensions.StartProcessAsCurrentUser("calc.exe");
+        
+        string solutionDirectory = Directory.GetParent(AppDomain.CurrentDomain.BaseDirectory).Parent.Parent.Parent.Parent.FullName;
+        string targetProjectName = Path.GetFileNameWithoutExtension(appPath);
+        string workDir = Path.Combine(solutionDirectory, targetProjectName, "bin", "Debug", "net6.0-windows");
+
+        /* NOTE YOU MUST COMMENT ONE OF THE BELOW LINES BASED ON YOUR CHOICE OF RUNNING THE SERVICE */
+
+        // DEBUG MODE
+        ProcessExtensions.LaunchProcess(appPath: appPath, workDir: workDir, asAdmin: false);
+
+        // SERVICE MODE
+        ProcessExtensions.LaunchProcess(appPath: appPath, workDir: workDir, asAdmin: true);
     }
 }

--- a/DemoModernService/DemoModernService.cs
+++ b/DemoModernService/DemoModernService.cs
@@ -1,6 +1,7 @@
 ﻿
 using Microsoft.Extensions.Hosting;
 using murrayju.ProcessExtensions;
+using System.Diagnostics;
 
 namespace DemoModernService;
 
@@ -8,6 +9,16 @@ internal class DemoModernService : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        ProcessExtensions.StartProcessAsCurrentUser("calc.exe");
+        string path = AppDomain.CurrentDomain.BaseDirectory;
+        int levelsUp = 5;
+        for (int i = 0; i < levelsUp; i++)
+        {
+            path = Directory.GetParent(path)?.FullName ?? path;
+        }
+        Debug.WriteLine("OUTPUT PATH: " + path);
+        string appPath = "AppWithPrivileges.exe";
+        string? workDir = Path.Combine(path, "AppWithPrivileges", "bin", "Debug", "net6.0-windows");
+        ProcessExtensions.StartProcessAsCurrentUser(appPath: appPath, workDir: workDir);
+        //ProcessExtensions.StartProcessAsCurrentUser("calc.exe");
     }
 }

--- a/DemoModernService/DemoModernService.csproj
+++ b/DemoModernService/DemoModernService.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DemoService/App.config
+++ b/DemoService/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/DemoService/DemoService.cs
+++ b/DemoService/DemoService.cs
@@ -12,7 +12,7 @@ namespace demo
 
         protected override void OnStart(string[] args)
         {
-            ProcessExtensions.StartProcessAsCurrentUser("calc.exe");
+            ProcessExtensions.LaunchProcess("calc.exe");
         }
 
         protected override void OnStop()

--- a/DemoService/DemoService.csproj
+++ b/DemoService/DemoService.csproj
@@ -8,10 +8,11 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>demo</RootNamespace>
     <AssemblyName>DemoService</AssemblyName>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -38,6 +39,9 @@
       <HintPath>..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8.1\System.Configuration.Install.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    </Reference>
     <Reference Include="System.ServiceProcess">
       <HintPath>..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8.1\System.ServiceProcess.dll</HintPath>
     </Reference>
@@ -68,6 +72,7 @@
     <None Include="deleteService.bat">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="ProjectInstaller.resx" />

--- a/DemoService/packages.config
+++ b/DemoService/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net48" />
+</packages>

--- a/ProcessExtensions/ProcessExtensions.cs
+++ b/ProcessExtensions/ProcessExtensions.cs
@@ -242,7 +242,7 @@ namespace murrayju.ProcessExtensions
             return bResult;
         }
 
-        public static bool LaunchProcess(string appPath, string cmdLine = null, string workDir = null, bool visible = true, bool asAdmin = false)
+        public static bool LaunchProcess(string appPath, string cmdLine = null, string workDir = null, bool visible = true)
         {
             var hUserToken = WindowsIdentity.GetCurrent().Token;
             var startInfo = new STARTUPINFO();
@@ -250,19 +250,21 @@ namespace murrayju.ProcessExtensions
             var pEnv = IntPtr.Zero;
             int iResultOfCreateProcessAsUser;
 
+            bool systemAccount = WindowsIdentity.GetCurrent().IsSystem;
+
 
             startInfo.cb = Marshal.SizeOf(typeof(STARTUPINFO));
 
             try
             {
                 //workDir = Path.GetDirectoryName(appPath);
-                if (!GetSessionUserToken(ref hUserToken, asAdmin))
+                if (!GetSessionUserToken(ref hUserToken, systemAccount))
                 {
                     throw new ProcessCreationException("StartProcessAsCurrentUser: GetSessionUserToken failed.");
                 }
 
                 int sessionId = (int)activeSessionId;
-                if (asAdmin && !SetTokenInformation(executionToken, TokenInformationClass.TokenSessionId, ref sessionId, sizeof(int)))
+                if (systemAccount && !SetTokenInformation(executionToken, TokenInformationClass.TokenSessionId, ref sessionId, sizeof(int)))
                 {
                     throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error(), "Failed to set token information.");
                 }

--- a/ProcessExtensions/ProcessExtensions.csproj
+++ b/ProcessExtensions/ProcessExtensions.csproj
@@ -4,4 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Security.Principal" Version="4.3.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ Similarly, the `DemoModernService` project uses .NET 8.0, and a build will copy 
 
 For either version, CD to the bin directory and run `createService` to install and start the service. It will launch `calc.exe` as soon as it starts. After that, run `deleteService` to stop and uninstall the service.
 
+## Major Addition
+Now you can run apps that require administrative privileges using the SetTokenInformation which can be used to update the session Id in which the app runs and hence show the app UI, note that you need to set the workDir parameter to the working directory which contains the app itself. See [this stack overflow answer](https://stackoverflow.com/questions/33212984/createprocessasuser-with-elevated-privileges)

--- a/solution.sln
+++ b/solution.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppWithPrivileges", "AppWithPrivileges\AppWithPrivileges.csproj", "{FB499E9E-A4E8-4201-9FD9-E70A0C80A9DD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{75EE3B51-5A96-473C-9E68-C36B728A6E2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{75EE3B51-5A96-473C-9E68-C36B728A6E2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{75EE3B51-5A96-473C-9E68-C36B728A6E2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB499E9E-A4E8-4201-9FD9-E70A0C80A9DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB499E9E-A4E8-4201-9FD9-E70A0C80A9DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB499E9E-A4E8-4201-9FD9-E70A0C80A9DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB499E9E-A4E8-4201-9FD9-E70A0C80A9DD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Previously, we couldn't load apps ui that require administrative privileges because of the fact that session ids being set to 0 (SYSTEM context) even though startInfo.lpDesktop = "winsta0\\default" was set inside the method. Now, with the usage of SetTokenInformation along with providing TOKEN_ALL_ACCESS to the current process token ( the service) we can load the app UI inside the interactive session.